### PR TITLE
Spam prevention for telegram and discord links

### DIFF
--- a/src/telegramBot/bridge/service.js
+++ b/src/telegramBot/bridge/service.js
@@ -12,8 +12,8 @@ const { bridgedMessagesCounter } = require("../../promMetrics/promCounters");
 
 // github copilot generated function to prevent telegram & discord links
 const isMessageSafeToSend = (message) => {
-  const telegramLinkPattern = /https?:\/\/(www\.)?t(elegram)?\.me\/[a-zA-Z0-9\-_]*/g;
-  const discordLinkPattern = /https?:\/\/(www\.)?discord\.gg\/[a-zA-Z0-9\-_]*/g;
+  const telegramLinkPattern = /(https?:\/\/)?(www\.)?t(elegram)?\.me\/[a-zA-Z0-9\-_]*/g;
+  const discordLinkPattern = /(https?:\/\/)?(www\.)?discord\.gg\/[a-zA-Z0-9\-_]*/g;
 
   if (telegramLinkPattern.test(message) || discordLinkPattern.test(message)) {
     return false;

--- a/src/telegramBot/bridge/service.js
+++ b/src/telegramBot/bridge/service.js
@@ -9,6 +9,19 @@ const cyrillicPattern = /^\p{Script=Cyrillic}+$/u;
 const { findCourseFromDb } = require("../../db/services/courseService");
 const { bridgedMessagesCounter } = require("../../promMetrics/promCounters");
 
+
+// github copilot generated function to prevent telegram & discord links
+const isMessageSafeToSend = (message) => {
+  const telegramLinkPattern = /https?:\/\/(www\.)?t(elegram)?\.me\/[a-zA-Z0-9\-_]*/g;
+  const discordLinkPattern = /https?:\/\/(www\.)?discord\.gg\/[a-zA-Z0-9\-_]*/g;
+
+  if (telegramLinkPattern.test(message) || discordLinkPattern.test(message)) {
+    return false;
+  }
+
+  return true;
+};
+
 const validDiscordChannel = async (courseName) => {
   const guild = await discordClient.guilds.fetch(process.env.GUILD_ID);
   courseName = courseName.replace(/ /g, "-").toLowerCase();
@@ -48,6 +61,11 @@ const sendMessageToDiscord = async (ctx, message, channel) => {
     if (message.content.text && message.content.text[0] === "/") {
       return;
     }
+    if(!isMessageSafeToSend(message.content.text)) {
+      console.log("Message contains a telegram or discord link");
+      return;
+    }
+
     const webhooks = await channel.fetchWebhooks();
     const webhook = webhooks.first();
     if (message.content.text) {
@@ -246,9 +264,10 @@ const validateContent = (content) => {
 };
 
 const sendMessageToTelegram = async (telegramId, content, sender, channel) => {
-  if (content === "") {
+  if (content === "" || !isMessageSafeToSend(content)) {
     return;
   }
+
   sender ? sender = escapeChars(sender) : sender = null;
   content = validateContent(content);
   try {


### PR DESCRIPTION
This pull request introduces simple link spam prevention to the bot. It checks if the message contains telegram or discord links and refuses to send the message forward along the bridge. This change does not prevent spam being sent, but decreases the amount of spam going between these two platforms.

Currently, we are received large quantities of discord and telegram channel invite links in the full stack open telegram channel (nearly 10k members) and it takes a while for the mods to react and remove those links.

Note: I have not tested this change as I do not know how. This pr might not work in its current form and might need changes from people who know the code better. If this bot is used on other channels / discords as well, this will prevent links being sent to those as well.

Also a disclosure: I don't know how this bot behaves in discord as I'm not in discord.

This kind of functionality must be added to the bot. The spam at times is getting out of hand.