### PR TITLE
Update to guide channel and Course creation

### DIFF
--- a/__tests__/jest/guide.test.js
+++ b/__tests__/jest/guide.test.js
@@ -1,0 +1,93 @@
+const { updateGuideMessage } = require("../../src/discordBot/services/guide");
+
+jest.mock("../../src/db/services/courseService", () => ({
+  findCoursesFromDb: jest.fn(),
+}));
+jest.mock("../../src/db/services/courseMemberService", () => ({
+  findCourseMemberCount: jest.fn(),
+}));
+
+const { findCoursesFromDb } = require("../../src/db/services/courseService");
+const { findCourseMemberCount } = require("../../src/db/services/courseMemberService");
+
+const createMockMessage = (id, content = "old content") => ({
+  id,
+  type: "DEFAULT",
+  content,
+  edit: jest.fn(),
+  delete: jest.fn(),
+});
+
+const setupMocks = (courseCount = 2, extraMessages = 1) => {
+  const courses = Array.from({ length: courseCount }, (_, i) => ({
+    id: i + 1,
+    code: `TKT10${i + 1}`,
+    fullName: `Course ${i + 1}`,
+    name: `tkt10${i + 1}`,
+  }));
+  findCoursesFromDb.mockResolvedValue(courses);
+  for (let i = 0; i < courseCount; i++) {
+    findCourseMemberCount.mockResolvedValueOnce((i + 1) * 5);
+  }
+
+  const infoMessage = { id: "info", edit: jest.fn() };
+  let courseMessages = Array.from({ length: courseCount }, (_, i) =>
+    createMockMessage(`msg${i + 1}`)
+  );
+  let extras = [];
+
+  if (extraMessages >= 0) {
+    extras = Array.from({ length: extraMessages }, (_, i) =>
+      createMockMessage(`extra${i + 1}`, "extra")
+    );
+  } else {
+    const removeCount = Math.abs(extraMessages);
+    if (removeCount > courseMessages.length) {
+      throw new Error("extraMessages is too negative, cannot remove more course messages than exist.");
+    }
+    courseMessages = courseMessages.slice(0, courseMessages.length - removeCount);
+  }
+
+  const sortedMessages = new Map([
+    ["info", infoMessage],
+    ...courseMessages.map((m) => [m.id, m]),
+    ...extras.map((m) => [m.id, m]),
+  ]);
+
+  const channel = {
+    send: jest.fn((content) =>
+      Promise.resolve({
+        react: jest.fn(() => Promise.resolve()),
+      })
+    ),
+  };
+
+  return { infoMessage, courseMessages, extras, sortedMessages, channel, courses };
+};
+
+describe("updateGuideMessage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("edits info message, edits existing course messages, deletes extras", async () => {
+    const { infoMessage, courseMessages, extras, sortedMessages, channel } = setupMocks(5, 1);
+
+    await updateGuideMessage(infoMessage, sortedMessages, channel, { Course: {}, CourseMember: {} });
+
+    expect(infoMessage.edit).toHaveBeenCalledTimes(1);
+    courseMessages.forEach(msg => expect(msg.edit).toHaveBeenCalledTimes(1));
+    expect(channel.send).not.toHaveBeenCalled();
+    extras.forEach(msg => expect(msg.delete).toHaveBeenCalledTimes(1));
+  });
+
+  test("sends new course messages when there are too few messages", async () => {
+    const { infoMessage, courseMessages, sortedMessages, channel } = setupMocks(5, -1);
+
+    await updateGuideMessage(infoMessage, sortedMessages, channel, { Course: {}, CourseMember: {} });
+
+    expect(infoMessage.edit).toHaveBeenCalledTimes(1);
+    expect(courseMessages[0].edit).toHaveBeenCalledTimes(1);
+    expect(channel.send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/jest/initialize.test.js
+++ b/__tests__/jest/initialize.test.js
@@ -5,6 +5,7 @@ const { client } = require("../mocks/mockClient");
 
 jest.mock("../../src/db/services/courseService");
 jest.mock("../../src/discordBot/services/service");
+jest.mock("../../src/discordBot/services/guide");
 jest.mock("../../src/db/hookInit");
 
 initHooks.mockImplementation(() => true);

--- a/__tests__/jest/service.test.js
+++ b/__tests__/jest/service.test.js
@@ -9,45 +9,9 @@ const {
   findOrCreateChannel,
   getCourseNameFromCategory,
   findChannelWithNameAndType,
-  getWorkshopInfo,
-  updateGuideMessage } = require("../../src/discordBot/services/service");
+  getWorkshopInfo } = require("../../src/discordBot/services/service");
 const { createCourseToDatabase, removeCourseFromDb } = require("../../src/db/services/courseService");
 const { data } = require("../mocks/workshopData.json");
-
-const createGuidePinnedMessage = async () => {
-  const rows = courses
-    .map((course) => {
-      const code = course.code;
-      const fullname = course.fullName;
-      const count = 1;
-      return `  - ${code} - ${fullname} 👤${count}`;
-    });
-
-  let invite_url = "";
-  process.env.NODE_ENV === "production" ? invite_url = `${process.env.BACKEND_SERVER_URL}` : invite_url = `${process.env.BACKEND_SERVER_URL}:${process.env.PORT}`;
-
-  const newContent = `
-Käytössäsi on seuraavia komentoja:
-  - \`/join\` jolla voit liittyä kurssille
-  - \`/leave\` jolla voit poistua kurssilta
-Kirjoittamalla \`/join\` tai \`/leave\` botti antaa listan kursseista.
-
-You have the following commands available:
-  - \`/join\` which you can use to join a course
-  - \`/leave\` which you can use to leave a course
-The bot gives a list of the courses if you type \`/join\` or \`/leave\`.
-
-Kurssit / Courses:
-${rows.join("\n")}
-
-In course specific channels you can also list instructors with the command \`/instructors\`
-
-See more with \`/help\` command.
-
-Invitation link for the server ${invite_url}
-`;
-  return newContent;
-};
 
 const courses = [{ code: "tkt", fullName: "test course", name: "test" }];
 
@@ -59,23 +23,6 @@ const Course = {
     .mockImplementationOnce(() => false),
   findAll: jest.fn(() => courses),
   destroy: jest.fn(),
-};
-
-const CourseMember = {
-  create: jest.fn(),
-  findOne: jest
-    .fn(() => true)
-    .mockImplementationOnce(() => false)
-    .mockImplementationOnce(() => false),
-  findAll: jest.fn(() => null),
-  count: jest
-    .fn()
-    .mockImplementationOnce(() => 1),
-  destroy: jest.fn(),
-};
-
-const models = {
-  Course, CourseMember,
 };
 
 const { client } = require("../mocks/mockSlashClient");
@@ -131,22 +78,6 @@ describe("Service", () => {
     const channel = { name: "guide", type: "GUILD_TEXT" };
     const channelFound = findChannelWithId(1, client.guild);
     expect(channelFound).toMatchObject(channel);
-  });
-
-  test("Update guide message", async () => {
-    const role = { name: "test", members: [] };
-    const guide = { id: 1, name: "guide", type: "GUILD_TEXT", send: jest.fn(() => msg) };
-    const commands = { id: 2, name: "commands", type: "GUILD_TEXT", send: jest.fn(() => msg) };
-    const testCategory = { id: 3, name: "📚 test", type: "GUILD_CATEGORY", members: {} };
-    client.guild.invites.cache.push({ channel: { name: "guide", code: 1 } });
-    client.guild.channels.cache = [guide, commands, testCategory];
-    client.guild.roles.cache = [role];
-    const msg = { guild: client.guild, pin: jest.fn(), edit: jest.fn() };
-    const guideMessage = await createGuidePinnedMessage(client.guild, Course);
-    await updateGuideMessage(msg, models);
-    expect(msg.edit).toHaveBeenCalledTimes(1);
-    expect(msg.edit).toHaveBeenCalledWith(guideMessage);
-    client.guild.channels.cache = [];
   });
 
   test("creating guide invitation call createInvite", async () => {

--- a/src/db/hooks/channelHooks.js
+++ b/src/db/hooks/channelHooks.js
@@ -7,8 +7,8 @@ const {
   getCategoryObject,
   getCategoryChannelPermissionOverwrites,
   createInvitation,
-  setCoursePositionABC,
-  updateGuide } = require("../../discordBot/services/service");
+  setCoursePositionABC } = require("../../discordBot/services/service");
+const { updateGuide } = require("../../discordBot/services/guide");
 const { findCourseFromDbById } = require("../services/courseService");
 const { courseAdminRole } = require("../../../config.json");
 const { Op } = require("sequelize");

--- a/src/db/hooks/courseHooks.js
+++ b/src/db/hooks/courseHooks.js
@@ -11,8 +11,8 @@ const {
   setEmojisUnlock,
   setEmojisHide,
   setEmojisUnhide,
-  setCoursePositionABC,
-  updateGuide } = require("../../discordBot/services/service");
+  setCoursePositionABC } = require("../../discordBot/services/service");
+const { updateGuide } = require("../../discordBot/services/guide");
 const { lockTelegramCourse, unlockTelegramCourse } = require("../../telegramBot/bridge/service");
 const { courseAdminRole } = require("../../../config.json");
 const { Op } = require("sequelize");

--- a/src/db/hooks/courseMemberHooks.js
+++ b/src/db/hooks/courseMemberHooks.js
@@ -18,7 +18,7 @@ const initCourseMemberHooks = (guild, models) => {
     logInfo("Member: " + member);
     const courseRole = guild.roles.cache.find(r => r.name === course.name);
     await member.roles.add(courseRole);
-    await updateGuide(guild, models);
+    //await updateGuide(guild, models);
     joinedUsersCounter.inc({ course: course.name });
   });
 
@@ -36,7 +36,7 @@ const initCourseMemberHooks = (guild, models) => {
     await member.fetch(true);
     const announcementChannel = guild.channels.cache.find(c => c.name === `${course.name}_announcement`);
     await updateAnnouncementChannelMessage(guild, announcementChannel);
-    await updateGuide(guild, models);
+    //await updateGuide(guild, models);
   });
 
   models.CourseMember.addHook("afterUpdate", async (courseMember) => {

--- a/src/db/hooks/courseMemberHooks.js
+++ b/src/db/hooks/courseMemberHooks.js
@@ -1,7 +1,7 @@
 const {
   updateAnnouncementChannelMessage,
-  updateGuide,
   updateInviteLinks } = require("../../discordBot/services/service");
+const { updateGuide } = require("../../discordBot/services/guide");
 const { findCourseFromDbById } = require("../services/courseService");
 const { findUserByDbId } = require("../services/userService");
 const { courseAdminRole } = require("../../../config.json");
@@ -35,11 +35,11 @@ const initCourseMemberHooks = (guild, models) => {
       .map(async role => await member.roles.remove(role)));
     await member.fetch(true);
     const announcementChannel = guild.channels.cache.find(c => c.name === `${course.name}_announcement`);
-    await updateAnnouncementChannelMessage(guild, announcementChannel);
+    await updateAnnouncementChannelMessage(guild, announcementChannel); //This should be only done if the user is an instructor
     //await updateGuide(guild, models);
   });
 
-  models.CourseMember.addHook("afterUpdate", async (courseMember) => {
+  models.CourseMember.addHook("afterUpdate", async (courseMember) => { // This makes no f****** sense. When a course gets new instructor update all courses announcement info ????
     if (courseMember._changed.has("instructor")) {
       await updateInviteLinks(guild);
     }

--- a/src/db/migrations/addUniqueConstraintToCourseCode-migration.js
+++ b/src/db/migrations/addUniqueConstraintToCourseCode-migration.js
@@ -1,0 +1,14 @@
+"use strict";
+
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.addConstraint("course", {
+      fields: ["code"],
+      type: "unique",
+    });
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeConstraint("course", "unique_course_code_constraint");
+  },
+};

--- a/src/discordBot/commands/admin/restore_server_from_database.js
+++ b/src/discordBot/commands/admin/restore_server_from_database.js
@@ -10,8 +10,8 @@ const {
   getCategoryChannelPermissionOverwrites,
   createInvitation,
   updateAnnouncementChannelMessage,
-  updateGuide,
   setCoursePositionABC } = require("../../services/service");
+const { updateGuide } = require("../../services/guide");
 const { courseAdminRole, facultyRole } = require("../../../../config.json");
 
 const execute = async (message, args, models) => {

--- a/src/discordBot/commands/faculty/add_instructors.js
+++ b/src/discordBot/commands/faculty/add_instructors.js
@@ -7,6 +7,11 @@ const { editEphemeral, editErrorEphemeral, sendEphemeral } = require("../../serv
 const { courseAdminRole, facultyRole } = require("../../../../config.json");
 
 const execute = async (interaction, client, models) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
+
   await sendEphemeral(interaction, "Adding instructors...");
 
   const courseModel = models.Course;

--- a/src/discordBot/commands/faculty/add_instructors.js
+++ b/src/discordBot/commands/faculty/add_instructors.js
@@ -7,7 +7,7 @@ const { editEphemeral, editErrorEphemeral, sendEphemeral } = require("../../serv
 const { courseAdminRole, facultyRole } = require("../../../../config.json");
 
 const execute = async (interaction, client, models) => {
-  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) { // Olisiko parempi tarkistaa tietokannasta eikä discordista?
     await sendEphemeral(interaction, "You do not have permission to use this command.");
     return
   }

--- a/src/discordBot/commands/faculty/create_channel.js
+++ b/src/discordBot/commands/faculty/create_channel.js
@@ -6,6 +6,11 @@ const { sendEphemeral, editEphemeral, editErrorEphemeral } = require("../../serv
 const { facultyRole } = require("../../../../config.json");
 
 const execute = async (interaction, client, models) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
+
   await sendEphemeral(interaction, "Creating text channel...");
 
   const courseModel = models.Course;

--- a/src/discordBot/commands/faculty/create_course.js
+++ b/src/discordBot/commands/faculty/create_course.js
@@ -58,7 +58,16 @@ const execute = async (interaction, client, models) => {
   const instructorRole = await interaction.guild.roles.cache.find(r => r.name === `${courseName} ${courseAdminRole}`);
   await interaction.member.roles.add(instructorRole);
 
-  await editEphemeral(interaction, `Created course ${courseName}.`);
+  //Generating final ephemeral message with #channel link in the message 
+  const channels = await interaction.guild.channels.fetch();
+  const courseChannel = channels.find(
+  c => c.name === `${courseName}_general` && c.type === "GUILD_TEXT"
+  );
+  let channelLink = "";
+  if (courseChannel) {
+    channelLink = `<#${courseChannel.id}>`;
+  }
+  await editEphemeral(interaction, `Created course ${courseName}. You have been added as an instructor of the course. You can find the course by clicking: ${channelLink || "Channel not found."} or among the listed courses on the sidebar.`);
 };
 
 module.exports = {

--- a/src/discordBot/commands/faculty/create_course.js
+++ b/src/discordBot/commands/faculty/create_course.js
@@ -8,6 +8,11 @@ const { sendErrorEphemeral, sendEphemeral, editEphemeral } = require("../../serv
 const { facultyRole } = require("../../../../config.json");
 
 const execute = async (interaction, client, models) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
+
   const courseCode = interaction.options.getString("coursecode").replace(/\s/g, "");
   const courseFullName = interaction.options.getString("full_name").trim();
   if (await findCourseFromDbWithFullName(courseFullName, models.Course)) return await sendErrorEphemeral(interaction, "Course fullname must be unique.");

--- a/src/discordBot/commands/faculty/create_poll.js
+++ b/src/discordBot/commands/faculty/create_poll.js
@@ -7,6 +7,10 @@ const { facultyRole } = require("../../../../config.json");
 const numbers = [ "1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣", "🔟" ];
 
 const execute = async (interaction, client) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
 
   const guild = client.guild;
   const channel = guild.channels.cache.get(interaction.channelId);

--- a/src/discordBot/commands/faculty/delete_bridge.js
+++ b/src/discordBot/commands/faculty/delete_bridge.js
@@ -7,6 +7,10 @@ const { sendMessageToTelegram } = require("../../../telegramBot/bridge/service")
 
 
 const execute = async (interaction, client, models) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
 
   await sendEphemeral(interaction, "Deleting bridge...");
   const Course = models.Course;

--- a/src/discordBot/commands/faculty/delete_channel.js
+++ b/src/discordBot/commands/faculty/delete_channel.js
@@ -7,6 +7,11 @@ const { confirmChoice } = require("../../services/confirm");
 const { facultyRole } = require("../../../../config.json");
 
 const execute = async (interaction, client, models) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
+
   await sendEphemeral(interaction, "Deleting text channel...");
   const channelModel = models.Channel;
   const courseModel = models.Course;

--- a/src/discordBot/commands/faculty/disable_bridge.js
+++ b/src/discordBot/commands/faculty/disable_bridge.js
@@ -7,6 +7,11 @@ const { confirmChoice } = require("../../services/confirm");
 const { facultyRole } = require("../../../../config.json");
 
 const execute = async (interaction, client, models) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
+
   await sendEphemeral(interaction, "Disabling the bridge to Telegram...");
 
   const channel = client.guild.channels.cache.get(interaction.channelId);

--- a/src/discordBot/commands/faculty/edit_course.js
+++ b/src/discordBot/commands/faculty/edit_course.js
@@ -66,6 +66,11 @@ const changeCourseNick = async (interaction, client, models, courseName, newValu
 };
 
 const execute = async (interaction, client, models) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
+
   await sendEphemeral(interaction, "Editing...");
   const guild = client.guild;
   const interactionChannel = guild.channels.cache.get(interaction.channelId);

--- a/src/discordBot/commands/faculty/edit_topic.js
+++ b/src/discordBot/commands/faculty/edit_topic.js
@@ -11,6 +11,11 @@ const { facultyRole } = require("../../../../config.json");
 const { saveChannelTopicToDb } = require("../../../db/services/channelService");
 
 const execute = async (interaction, client, models) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
+
   await sendEphemeral(interaction, "Editing topic...");
   const newTopic = interaction.options.getString("topic").trim();
 

--- a/src/discordBot/commands/faculty/enable_bridge.js
+++ b/src/discordBot/commands/faculty/enable_bridge.js
@@ -7,6 +7,11 @@ const { confirmChoice } = require("../../services/confirm");
 const { facultyRole } = require("../../../../config.json");
 
 const execute = async (interaction, client, models) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
+
   await sendEphemeral(interaction, "Enabling the bridge to Telegram...");
 
   const channel = client.guild.channels.cache.get(interaction.channelId);

--- a/src/discordBot/commands/faculty/hide_channel.js
+++ b/src/discordBot/commands/faculty/hide_channel.js
@@ -5,6 +5,11 @@ const { facultyRole } = require("../../../../config.json");
 const { confirmChoice } = require("../../services/confirm");
 
 const execute = async (interaction, client, models) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
+
   await sendEphemeral(interaction, "Hiding text channel...");
 
   const channelModel = models.Channel;

--- a/src/discordBot/commands/faculty/hide_course.js
+++ b/src/discordBot/commands/faculty/hide_course.js
@@ -9,6 +9,11 @@ const { confirmChoice } = require("../../services/confirm");
 const { facultyRole } = require("../../../../config.json");
 
 const execute = async (interaction, client, models) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
+
   await sendEphemeral(interaction, "Hiding course...");
   const courseName = interaction.options.getString("course").trim();
 

--- a/src/discordBot/commands/faculty/lock_chat.js
+++ b/src/discordBot/commands/faculty/lock_chat.js
@@ -10,6 +10,11 @@ const { confirmChoice } = require("../../services/confirm");
 const { facultyRole } = require("../../../../config.json");
 
 const execute = async (interaction, client, models) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
+
   await sendEphemeral(interaction, "Locking course...");
   const courseName = interaction.options.getString("course").trim();
   const guild = client.guild;

--- a/src/discordBot/commands/faculty/remove_instructors.js
+++ b/src/discordBot/commands/faculty/remove_instructors.js
@@ -7,6 +7,11 @@ const { editEphemeral, editErrorEphemeral, sendEphemeral } = require("../../serv
 const { courseAdminRole, facultyRole } = require("../../../../config.json");
 
 const execute = async (interaction, client, models) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
+
   await sendEphemeral(interaction, "Removing instructors...");
 
   const courseModel = models.Course;

--- a/src/discordBot/commands/faculty/rename_channel.js
+++ b/src/discordBot/commands/faculty/rename_channel.js
@@ -7,6 +7,11 @@ const { facultyRole } = require("../../../../config.json");
 const { confirmChoice } = require("../../services/confirm");
 
 const execute = async (interaction, client, models) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
+
   await sendEphemeral(interaction, "Renaming text channel...");
 
   const courseModel = models.Course;

--- a/src/discordBot/commands/faculty/status.js
+++ b/src/discordBot/commands/faculty/status.js
@@ -14,6 +14,11 @@ const { findAllCourseMembers } = require("../../../db/services/courseMemberServi
 
 
 const execute = async (interaction, client, models) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
+
   await sendEphemeral(interaction, "Fetching status...");
   const guild = client.guild;
   const channel = guild.channels.cache.get(interaction.channelId);

--- a/src/discordBot/commands/faculty/unhide_channel.js
+++ b/src/discordBot/commands/faculty/unhide_channel.js
@@ -5,6 +5,11 @@ const { facultyRole } = require("../../../../config.json");
 const { confirmChoice } = require("../../services/confirm");
 
 const execute = async (interaction, client, models) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
+
   await sendEphemeral(interaction, "Unhiding text channel...");
 
   const channelModel = models.Channel;

--- a/src/discordBot/commands/faculty/unhide_course.js
+++ b/src/discordBot/commands/faculty/unhide_course.js
@@ -9,6 +9,11 @@ const { confirmChoice } = require("../../services/confirm");
 const { facultyRole } = require("../../../../config.json");
 
 const execute = async (interaction, client, models) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
+
   await sendEphemeral(interaction, "Unhiding course...");
   const courseName = interaction.options.getString("course").trim();
 

--- a/src/discordBot/commands/faculty/unlock_chat.js
+++ b/src/discordBot/commands/faculty/unlock_chat.js
@@ -9,6 +9,11 @@ const { confirmChoice } = require("../../services/confirm");
 const { facultyRole } = require("../../../../config.json");
 
 const execute = async (interaction, client, models) => {
+  if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
+    await sendEphemeral(interaction, "You do not have permission to use this command.");
+    return
+  }
+
   await sendEphemeral(interaction, "Unlocking course...");
   const courseName = interaction.options.getString("course").trim();
   const guild = client.guild;

--- a/src/discordBot/events/guildMemberAdd.js
+++ b/src/discordBot/events/guildMemberAdd.js
@@ -1,4 +1,4 @@
-const { updateGuide } = require("../../discordBot/services/service");
+const { updateGuide } = require("../../discordBot/services/guide");
 const { createUserToDatabase } = require("../../db/services/userService");
 
 const execute = async (member, client, models) => {

--- a/src/discordBot/events/guildMemberRemove.js
+++ b/src/discordBot/events/guildMemberRemove.js
@@ -1,4 +1,4 @@
-const { updateGuide } = require("../../discordBot/services/service");
+const { updateGuide } = require("../../discordBot/services/guide");
 const { removeUserFromDb } = require("../../db/services/userService");
 
 const execute = async (member, client, models) => {

--- a/src/discordBot/events/messageReactionAdd.js
+++ b/src/discordBot/events/messageReactionAdd.js
@@ -23,7 +23,7 @@ const execute = async (reaction, user, client, models) => {
     const member = await guild.members.fetch(user.id);
 
     // Extract the course code from the message
-    const courseNameMatch = message.content.match(/([A-Za-z0-9]+) -/);
+    const courseNameMatch = message.content.match(/([A-Za-z0-9äöåÄÖÅ]+) -/);
     if (!courseNameMatch) {
         console.error("Couldn't parse course code from message:", message.content);
         return;

--- a/src/discordBot/events/messageReactionAdd.js
+++ b/src/discordBot/events/messageReactionAdd.js
@@ -1,0 +1,79 @@
+
+const { findCourseFromDb } = require("../../db/services/courseService");
+const { findUserByDiscordId, createUserToDatabase } = require("../../db/services/userService");
+const { createCourseMemberToDatabase, removeCourseMemberFromDb, findAllCourseMembersByUser } = require("../../db/services/courseMemberService");
+
+const emoji = "👤";
+const GUIDE_CHANNEL_NAME = "guide";
+
+const execute = async (reaction, user, client, models) => {
+    console.log("täällä")
+    if (user.bot) return;
+
+    const { message } = reaction;
+    const channel = message.channel;
+
+    //Make sure it is in the guide channel and the right reaction
+    if (channel.name !== GUIDE_CHANNEL_NAME) return;
+    if (reaction.emoji.name !== emoji) {
+        await reaction.users.remove(user.id); // Still remove the reaction to clean up
+        return
+    };
+
+    const guild = message.guild;
+    const member = await guild.members.fetch(user.id);
+
+    // Extract the course code from the message
+    const courseNameMatch = message.content.match(/([A-Za-z0-9]+) -/);
+    if (!courseNameMatch) {
+        console.error("Couldn't parse course code from message:", message.content);
+        return;
+    }
+    const courseCode = courseNameMatch[1];
+
+    // Find the course from the database
+    const course = await findCourseFromDb(courseCode, models.Course);
+    if (!course || course.private) {
+      console.error(`Course not found or private: ${courseCode}`);
+      return;
+    }
+
+    // Find or create the user in the database
+    let dbUser = await findUserByDiscordId(user.id, models.User);
+    if (!dbUser) {
+      console.log("added user to db")
+      await createUserToDatabase(user.id, user.username, models.User);
+      dbUser = await findUserByDiscordId(user.id, models.User);
+    }
+
+    // Find what courses the user is already in
+    const courseMembers = await findAllCourseMembersByUser(dbUser.id, models.CourseMember);
+    const coursesJoinedByUser = courseMembers.map(cm => cm.courseId);
+
+    const isAlreadyInCourse = coursesJoinedByUser.includes(course.id);
+
+    // Always remove their reaction
+    console.log("try removing reaction")
+    await reaction.users.remove(user.id);
+    console.log("attempt done")
+
+    if (isAlreadyInCourse) {
+      // User is already in the course -> REMOVE them
+      console.log(`Removing user ${user.username} from course ${courseCode} via reaction.`);
+      await removeCourseMemberFromDb(dbUser.id, course.id, models.CourseMember);
+      console.log(`Removed user.`);
+
+    } else {
+      // User is not in the course -> ADD them
+      console.log(`Adding user ${user.username} to course ${courseCode} via reaction.`);
+      await createCourseMemberToDatabase(dbUser.id, course.id, models.CourseMember);
+      console.log(`Added user.`);
+    }
+}
+
+
+
+module.exports = {
+    name: "messageReactionAdd",
+    execute,
+};

--- a/src/discordBot/events/messageReactionAdd.js
+++ b/src/discordBot/events/messageReactionAdd.js
@@ -7,7 +7,6 @@ const emoji = "👤";
 const GUIDE_CHANNEL_NAME = "guide";
 
 const execute = async (reaction, user, client, models) => {
-    console.log("täällä")
     if (user.bot) return;
 
     const { message } = reaction;
@@ -16,7 +15,7 @@ const execute = async (reaction, user, client, models) => {
     //Make sure it is in the guide channel and the right reaction
     if (channel.name !== GUIDE_CHANNEL_NAME) return;
     if (reaction.emoji.name !== emoji) {
-        await reaction.users.remove(user.id); // Still remove the reaction to clean up
+        await reaction.users.remove(user.id); // Still remove the reaction if it's not the correct one
         return
     };
 

--- a/src/discordBot/services/command.js
+++ b/src/discordBot/services/command.js
@@ -68,15 +68,15 @@ const updateDynamicChoices = async (client, commandNames, Course) => {
         ),
     };
     if (obj.data.name === "join" || obj.data.name === "hide_course") {
-      await addOptions(c, obj, await findPublicCoursesFromDb("code", Course));
+      await addOptions(c, obj, (await findPublicCoursesFromDb("code", Course)).slice(0,24));
     } else if (obj.data.name === "leave") {
-      await addOptions(c, obj, await findCoursesFromDb("code", Course));
+      await addOptions(c, obj, (await findCoursesFromDb("code", Course)).slice(0,24));
     } else if (obj.data.name === "unhide_course") {
-      await addOptions(c, obj, await findPrivateCoursesFromDb("code", Course));
+      await addOptions(c, obj, (await findPrivateCoursesFromDb("code", Course)).slice(0,24));
     } else if (obj.data.name === "lock_chat") {
-      await addOptions(c, obj, await findUnlockedCoursesFromDb("code", Course));
+      await addOptions(c, obj, (await findUnlockedCoursesFromDb("code", Course)).slice(0,24));
     } else if (obj.data.name === "unlock_chat") {
-      await addOptions(c, obj, await findLockedCoursesFromDb("code", Course));
+      await addOptions(c, obj, (await findLockedCoursesFromDb("code", Course)).slice(0,24));
     }
   });
 };

--- a/src/discordBot/services/guide.js
+++ b/src/discordBot/services/guide.js
@@ -82,7 +82,6 @@ Invitation link for the server ${invite_url}
     const courseMessage = courseMessages[i];
 
     if (courseMessage) {
-      console.log("editing guide messages:", (courseMessage.content == rowContent ? "current message is already correct":"current message is wrong: changing"), rowContent)
       if (courseMessage.content !== rowContent) {
         editOrSendPromises.push(courseMessage.edit(rowContent));
       }

--- a/src/discordBot/services/guide.js
+++ b/src/discordBot/services/guide.js
@@ -1,0 +1,107 @@
+const { findCoursesFromDb, findAllCourseNames, findCourseFromDb } = require("../../db/services/courseService");
+const { findCourseMemberCount } = require("../../db/services/courseMemberService");
+
+require("dotenv").config();
+const GUIDE_CHANNEL_NAME = "guide";
+
+let invite_url = "";
+
+process.env.NODE_ENV === "production" ? invite_url = `${process.env.BACKEND_SERVER_URL}` : invite_url = `${process.env.BACKEND_SERVER_URL}:${process.env.PORT}`;
+
+
+const updateGuide = async (guild, models) => {
+  const channel = guild.channels.cache.find(
+    (c) => c.name === GUIDE_CHANNEL_NAME,
+  );
+
+  if (!channel) {
+    console.error("Guide channel not found!");
+    return;
+  }
+
+  const messages = await channel.messages.fetch({ limit: 100 });
+  const sortedMessages = messages.sort((a, b) => a.createdTimestamp - b.createdTimestamp);
+  const infoMessage = sortedMessages.first();
+
+  if (!infoMessage) {
+    console.error("No info message found! Delete the guide channel and launch the bot again to init the message.");
+    return;
+  }
+
+  await updateGuideMessage(infoMessage, sortedMessages, channel, models);
+};
+
+const updateGuideMessage = async (infoMessage, sortedMessages, channel, models) => {
+  const courseData = await findCoursesFromDb("code", models.Course, false);
+
+  // Collect all course member counts in parallel - faster fetching
+  const courseMemberCounts = await Promise.all(courseData.map(course =>
+    findCourseMemberCount(course.id, models.CourseMember)
+  ));
+
+  // Now build rows without additional awaits
+  const rows = courseData.map((course, index) => {
+    const regExp = /[^0-9]*/;
+    const fullname = course.fullName;
+    const name = course.name;
+    const matches = regExp.exec(course.code)?.[0];
+    const code = matches ? matches + course.code.slice(matches.length) : course.code;
+    const count = courseMemberCounts[index];
+    return `${name} - ${code} - ${fullname} 👥${count}`;
+  });
+
+  const infoContent = `
+Käytössäsi on seuraavia komentoja:
+  - \`/join\` jolla voit liittyä kurssille
+  - \`/leave\` jolla voit poistua kurssilta
+Kirjoittamalla \`/join\` tai \`/leave\` botti antaa listan kursseista.
+
+You have the following commands available:
+  - \`/join\` which you can use to join a course
+  - \`/leave\` which you can use to leave a course
+The bot gives a list of the courses if you type \`/join\` or \`/leave\`.
+
+In course specific channels you can also list instructors with the command \`/instructors\`
+
+See more with \`/help\` command.
+
+Invitation link for the server ${invite_url}
+`.trim(); // <-- .trim() here to remove leading/trailing whitespace
+
+  const messagesArray = Array.from(sortedMessages.values());
+
+  const courseMessages = messagesArray.filter(m => m.id !== infoMessage.id && m.type !== 'CHANNEL_PINNED_MESSAGE');
+
+  // Edit the info message first
+  await infoMessage.edit(infoContent);
+
+  // Prepare promises for editing/sending messages instead of awaiting one-by-one
+  const editOrSendPromises = [];
+
+  for (let i = 0; i < rows.length; i++) {
+    const rowContent = rows[i];
+    const courseMessage = courseMessages[i];
+
+    if (courseMessage) {
+      editOrSendPromises.push(courseMessage.edit(rowContent));
+    } else {
+      // If no courseMessage exists, send a new message and react to it
+      editOrSendPromises.push(
+        channel.send(rowContent).then(msg => msg.react("👤"))
+      );
+    }
+  }
+
+  await Promise.all(editOrSendPromises); // Await all at once
+
+  // Delete any extra old course messages
+  if (courseMessages.length > rows.length) {
+    const deletePromises = courseMessages.slice(rows.length).map(msg => msg.delete());
+    await Promise.all(deletePromises);
+  }
+};
+
+module.exports = {
+  updateGuide,
+  updateGuideMessage,
+};

--- a/src/discordBot/services/guide.js
+++ b/src/discordBot/services/guide.js
@@ -83,7 +83,7 @@ Invitation link for the server ${invite_url}
 
     if (courseMessage) {
       console.log("editing guide messages:", (courseMessage.content == rowContent ? "current message is already correct":"current message is wrong: changing"), rowContent)
-      if (!courseMessage.content == rowContent) {
+      if (courseMessage.content !== rowContent) {
         editOrSendPromises.push(courseMessage.edit(rowContent));
       }
     } else {

--- a/src/discordBot/services/init.js
+++ b/src/discordBot/services/init.js
@@ -1,6 +1,6 @@
 const { findOrCreateRoleWithName } = require("./service");
 const { facultyRole, githubRepo } = require("../../../config.json");
-const { updateGuide } = require("../../discordBot/services/service");
+const { updateGuide } = require("../../discordBot/services/guide");
 const { initHooks } = require("../../db/hookInit");
 const { sendPullDateMessage } = require("./message");
 
@@ -54,6 +54,7 @@ const initRoles = async (guild) => {
 };
 
 const setInitialGuideMessage = async (guild, channelName, models) => {
+  console.log("Started initializing guide message")
   const guideChannel = guild.channels.cache.find(c => c.type === "GUILD_TEXT" && c.name === channelName);
   if (!guideChannel.lastPinTimestamp) {
     const msg = await guideChannel.send("initial");
@@ -63,13 +64,14 @@ const setInitialGuideMessage = async (guild, channelName, models) => {
   const guideinvite = invs.find(invite => invite.channel.name === "guide");
   if (!guideinvite) await guideChannel.createInvite({ maxAge: 0 });
   await updateGuide(guild, models);
+  console.log("Guide message initialized and updated")
 };
 
 const initializeApplicationContext = async (client, models) => {
   initHooks(client.guild, models);
   await initRoles(client.guild);
   await initChannels(client.guild, client);
-  await setInitialGuideMessage(client.guild, "guide", models);
+  setInitialGuideMessage(client.guild, "guide", models);
 
   if (process.env.NODE_ENV === "production") {
     await sendPullDateMessage(client);

--- a/src/discordBot/services/service.js
+++ b/src/discordBot/services/service.js
@@ -275,6 +275,11 @@ const updateGuide = async (guild, models) => {
     (c) => c.name === GUIDE_CHANNEL_NAME,
   );
 
+  if (!channel) {
+    console.error("Guide channel not found!");
+    return;
+  }
+
   const messages = await channel.messages.fetch({ limit: 100 });
   const sortedMessages = messages.sort((a, b) => a.createdTimestamp - b.createdTimestamp);
   const infoMessage = sortedMessages.first();

--- a/src/discordBot/services/service.js
+++ b/src/discordBot/services/service.js
@@ -293,10 +293,11 @@ const updateGuideMessage = async (message, sortedMessages, channel, models) => {
   const rows = await Promise.all(courseData.map(async (course) => {
     const regExp = /[^0-9]*/;
     const fullname = course.fullName;
+    const name = course.name
     const matches = regExp.exec(course.code)?.[0];
     const code = matches ? matches + course.code.slice(matches.length) : course.code;
     const count = await findCourseMemberCount(course.id, models.CourseMember);
-    return `${code} - ${fullname} 👤${count}`;
+    return `${name} - ${code} - ${fullname} 👥${count}`;
   }));
 
   const infoContent = `


### PR DESCRIPTION
### Pull Request features:
- Guide channel has been overhauled for easy course joining and leaving
  - Courses are listed as separate messages with a toggle (reaction) button for each course for joining/leaving courses
- Creating a course now adds the creator as a member and an instructor of the course
  - Also the final ephemeral message edit that confirms the course creation has a clickable #channel link that directs the creator to the courses general channel.
- Fix for faculty commands role authentication (This feature is already implemented earlier as a hot fix. More below in merge section)

### Merge details
> [!NOTICE]
> This Pull Request adds a restriction to the database: No duplicate course codes. Most likely this restriction won't cause any issue but maybe it should be checked before pushing the code as noncompliance will just crash the instance.

I have tested migrating from current state to new guide and it seems to migrate without issues.

> [!CAUTION]
>Everything else in the merge should be clear except faculty command files. At the start of their execute methods both repos have the same code from different commits. `create_course.js` is an exception as it has more changes.
>
>There is duplicate commits for the faculty command role authentication as it needed to be express fixed earlier. Every faculty command file has this code:
>```js
>if (!interaction.member.permissions.has("ADMINISTRATOR") && !interaction.member.roles.cache.some(r => r.name === facultyRole)) {
>    await sendEphemeral(interaction, "You do not have permission to use this command.");
>    return
>}
>```

I'll do the merge after the database has been checked for the new restriction: "No duplicate course codes".